### PR TITLE
CORPL-1244 FAOPS-3702 Adds FA-specific info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FA notes
 
-This is our Slackbot that monitors for old PRs and posts in Slack. This helps us keep on top of 
+This is our Slackbot that monitors for old PRs and posts in Slack. This helps us keep on top of PRs that are aging. We want PRs to be reviewed quickly! https://futureadvisor.atlassian.net/wiki/spaces/DEV/pages/32636979/Submitting+Pull+Requests
 
 If you want to make any modifications (set up a new Angry Seal monitor) you can look at https://futureadvisor.atlassian.net/browse/PROD-3608 as a reference.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# FA notes
+
+This is our Slackbot that monitors for old PRs and posts in Slack. This helps us keep on top of 
+
+If you want to make any modifications (set up a new Angry Seal monitor) you can look at https://futureadvisor.atlassian.net/browse/PROD-3608 as a reference.
+
+https://ci-master.infra.futureadvisor.com/view/SRE/job/Seal/configure is the main configuration.
+
 # Seal
 [![Build Status](https://travis-ci.org/binaryberry/seal.svg)](https://travis-ci.org/binaryberry/seal)
 


### PR DESCRIPTION
This mostly overlaps with https://futureadvisor.atlassian.net/browse/FAOPS-3702 and is linked to https://futureadvisor.atlassian.net/browse/CORPL-1244 b/c it's comments-only